### PR TITLE
Allocate 1 passed the dimension's size.

### DIFF
--- a/dungeon.h
+++ b/dungeon.h
@@ -33,7 +33,7 @@ void dungeon_create_rooms(dungeon* d) {
 	const int h = d->height;
 	const int num = (w*h);
 	int x;
-	d->rooms = calloc((unsigned long)num, sizeof(room));
+	d->rooms = calloc((unsigned long)num + 1, sizeof(room)); // XXX add 1 up, passed w * h
 
 	for(x=0; x<num; ++x) {
 		dungeon_room_create(&(d->rooms[x]));


### PR DESCRIPTION
This was the valgrind output from before the edit:

```
==19997== Memcheck, a memory error detector
==19997== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==19997== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==19997== Command: ./game
==19997== Parent PID: 18425
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x804929B: dungeon_create_rooms (dungeon.h:70)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997==  Address 0x420e179 is 1 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x80492B5: dungeon_create_rooms (dungeon.h:70)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997==  Address 0x420e179 is 1 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid write of size 1
==19997==    at 0x80492BE: dungeon_create_rooms (dungeon.h:70)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997==  Address 0x420e179 is 1 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 4
==19997==    at 0x8049D93: get_desc (main.c:158)
==19997==    by 0x804A516: main (main.c:328)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x804987B: dungeon_set_stage (dungeon.h:199)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x80498FE: dungeon_set_stage (dungeon.h:209)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x804993C: dungeon_set_stage (dungeon.h:213)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e179 is 1 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x8049964: dungeon_set_stage (dungeon.h:217)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e179 is 1 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x804998C: dungeon_set_stage (dungeon.h:221)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x80499AB: dungeon_set_stage (dungeon.h:225)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 1
==19997==    at 0x80499DD: dungeon_set_stage (dungeon.h:229)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid write of size 1
==19997==    at 0x80499E3: dungeon_set_stage (dungeon.h:229)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 2
==19997==    at 0x8049A55: dungeon_set_stage (dungeon.h:234)
==19997==    by 0x804A524: main (main.c:329)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== Invalid read of size 4
==19997==    at 0x8049EF0: action_move (main.c:186)
==19997==    by 0x804A559: main (main.c:331)
==19997==  Address 0x420e178 is 0 bytes after a block of size 8 alloc'd
==19997==    at 0x402C435: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==19997==    by 0x8049009: dungeon_create_rooms (dungeon.h:36)
==19997==    by 0x80494A3: dungeon_create (dungeon.h:94)
==19997==    by 0x804A4F7: main (main.c:323)
==19997== 
==19997== 
==19997== HEAP SUMMARY:
==19997==     in use at exit: 0 bytes in 0 blocks
==19997==   total heap usage: 12 allocs, 12 frees, 880 bytes allocated
==19997== 
==19997== All heap blocks were freed -- no leaks are possible
==19997== 
==19997== For counts of detected and suppressed errors, rerun with: -v
==19997== ERROR SUMMARY: 14 errors from 14 contexts (suppressed: 0 from 0)
```

And after:

```
==20550== Memcheck, a memory error detector
==20550== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==20550== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==20550== Command: ./game
==20550== Parent PID: 20159
==20550== 
==20550== 
==20550== HEAP SUMMARY:
==20550==     in use at exit: 0 bytes in 0 blocks
==20550==   total heap usage: 12 allocs, 12 frees, 884 bytes allocated
==20550== 
==20550== All heap blocks were freed -- no leaks are possible
==20550== 
==20550== For counts of detected and suppressed errors, rerun with: -v
==20550== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
